### PR TITLE
Use only visual 193 and use new epoch

### DIFF
--- a/.c3i/config_v2.yml
+++ b/.c3i/config_v2.yml
@@ -50,7 +50,7 @@ tasks:
 
 configurations:
   - id: windows-msvc
-    epochs: [0, 20211221, 20220120, 20220628]
+    epochs: [20230606]
     hrname: "Windows, MSVC"
     build_profile:
       os: "Windows"
@@ -59,7 +59,7 @@ configurations:
         arch: [ "x86_64" ]
         compiler:
           - "msvc":
-              compiler.version: [ "192", "193" ]
+              compiler.version: [ "193" ]
               build_type:
                 - "Release":
                     compiler.runtime: ["dynamic"]


### PR DESCRIPTION
Setting a new (higher) epoch for this is good because:
- if the epoch is higher in properties (artifactory) than the ones available in profiles, then the highest epoch found in profiles is used.

But, we have to keep in mind that:

- if the epoch is higher in properties (artifactory) than the ones available in profiles but requirements are in a lower epoch, then the lowest epoch in the requirements is used.

So, when we add the new config in c3i for the PRs to build it, we have to set all the Windows profiles together in the new epoch